### PR TITLE
Fix for mc 1.21.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>RedstoneProximitySensor</name>
     <groupId>com.ugleh</groupId>
     <artifactId>RedstoneProximitySensor</artifactId>
-    <version>2.5.2</version>
+    <version>2.5.3</version>
     <modelVersion>4.0.0</modelVersion>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.5.3</version>
                 <configuration>
                     <relocations>
                         <relocation>
@@ -50,6 +50,21 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <!-- Towny -->
+        <repository>
+            <id>glaremasters repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
+        <!-- GriefPrevention -->
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+        <!-- LegacyFactions -->
+		<repository>
+			<id>minebench</id>
+			<url>https://repo.minebench.de</url>
+		</repository>
     </repositories>
     <dependencies>
         <dependency>
@@ -58,11 +73,10 @@
             <scope>compile</scope>
             <version>5.3.1</version>
         </dependency>
-        <!-- Dependency used for the Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <artifactId>spigot</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Dependency used for the Metrics -->
@@ -72,34 +86,21 @@
             <version>1.5</version>
             <scope>compile</scope>
         </dependency>
-        <!-- Dependencies used for the plugins with native support -->
         <dependency>
-            <groupId>me.unknown</groupId>
-            <artifactId>spigot</artifactId>
-            <scope>system</scope>
-            <version>1.0</version>
-            <systemPath>${project.basedir}/../../spigot-1.16.4.jar</systemPath>
-        </dependency>
-        <dependency>
-            <groupId>me.unknown</groupId>
+            <groupId>com.github.TechFortress</groupId>
             <artifactId>GriefPrevention</artifactId>
-            <scope>system</scope>
-            <version>1.0</version>
-            <systemPath>${project.basedir}/../../GriefPrevention.jar</systemPath>
+			<version>master-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>me.unknown</groupId>
-            <artifactId>LegacyFactions</artifactId>
-            <scope>system</scope>
-            <version>1.0</version>
-            <systemPath>${project.basedir}/../../LegacyFactions.jar</systemPath>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>0.100.3.0</version>
+            <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>me.unknown</groupId>
-            <artifactId>Towny</artifactId>
-            <scope>system</scope>
-            <version>1.0</version>
-            <systemPath>${project.basedir}/../../Towny.jar</systemPath>
-        </dependency>
+		<dependency>
+			<groupId>net.redstoneore.legacyfactions</groupId>
+			<artifactId>legacyfactions</artifactId>
+			<version>1.3.0</version>
+		</dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
             <groupId>com.github.TechFortress</groupId>
             <artifactId>GriefPrevention</artifactId>
 			<version>master-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
@@ -101,6 +102,7 @@
 			<groupId>net.redstoneore.legacyfactions</groupId>
 			<artifactId>legacyfactions</artifactId>
 			<version>1.3.0</version>
+            <scope>provided</scope>
 		</dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/ugleh/redstoneproximitysensor/RedstoneProximitySensor.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/RedstoneProximitySensor.java
@@ -111,7 +111,7 @@ public class RedstoneProximitySensor extends JavaPlugin {
 
     private void createSensorItemstack() {
         rpsItemStack = new ItemStack(Material.REDSTONE_TORCH, 1);
-        rpsItemStack.addUnsafeEnchantment(Enchantment.ARROW_DAMAGE, 1);
+        rpsItemStack.addUnsafeEnchantment(Enchantment.POWER, 1);
         ItemMeta rpsMeta = rpsItemStack.getItemMeta();
         assert rpsMeta != null;
         rpsMeta.setDisplayName(ChatColor.RED + this.langStringColor("lang_main_itemname"));

--- a/src/main/java/com/ugleh/redstoneproximitysensor/addons/TownyTrigger.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/addons/TownyTrigger.java
@@ -1,10 +1,10 @@
 package com.ugleh.redstoneproximitysensor.addons;
 
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.ugleh.redstoneproximitysensor.RedstoneProximitySensor;
 import com.ugleh.redstoneproximitysensor.listener.PlayerListener;
 import com.ugleh.redstoneproximitysensor.util.RPS;
@@ -44,11 +44,11 @@ public class TownyTrigger extends TriggerTemplate {
         Location l = rps.getLocation();
         if (!rps.getAcceptedTriggerFlags().contains(flagName)) return TriggerCreator.TriggerResult.NOT_TRIGGERED;
         if (!(e instanceof Player)) return TriggerCreator.TriggerResult.NOT_TRIGGERED;
-        if (TownyUniverse.isWilderness(l.getBlock())) return TriggerCreator.TriggerResult.NOT_TRIGGERED;
+        if (TownyAPI.getInstance().isWilderness(l.getBlock())) return TriggerCreator.TriggerResult.NOT_TRIGGERED;
         try {
-            Resident r = TownyUniverse.getDataSource().getResident(e.getName());
+            Resident r = TownyAPI.getInstance().getResident(e.getName());
             Town rTown = r.getTown();
-            boolean isWild = TownyUniverse.isWilderness(l.getBlock());
+            boolean isWild = TownyAPI.getInstance().isWilderness(l.getBlock());
             if (isWild && rTown == null) {
                 return TriggerCreator.TriggerResult.TRIGGERED;
             } else if (!isWild && rTown == null) {
@@ -56,8 +56,8 @@ public class TownyTrigger extends TriggerTemplate {
             } else if (isWild && rTown != null) {
                 return TriggerCreator.TriggerResult.NOT_TRIGGERED;
             }
-            TownBlock townBlock = TownyUniverse.getTownBlock(l);
-            if (townBlock.getTown().getUID() == rTown.getUID()) return TriggerCreator.TriggerResult.TRIGGERED;
+            TownBlock townBlock = TownyAPI.getInstance().getTownBlock(l);
+            if (townBlock.getTown().getUUID() == rTown.getUUID()) return TriggerCreator.TriggerResult.TRIGGERED;
             else return TriggerCreator.TriggerResult.NOT_TRIGGERED;
         } catch (NotRegisteredException e1) {
             e1.printStackTrace();

--- a/src/main/java/com/ugleh/redstoneproximitysensor/command/CommandRPS.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/command/CommandRPS.java
@@ -13,7 +13,7 @@ import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.craftbukkit.v1_16_R3.command.CraftBlockCommandSender;
+import org.bukkit.craftbukkit.v1_21_R1.command.CraftBlockCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 

--- a/src/main/java/com/ugleh/redstoneproximitysensor/listener/PlayerListener.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/listener/PlayerListener.java
@@ -56,7 +56,7 @@ public class PlayerListener implements Listener {
         itemMeta.setLore(lore);
         itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-        itemMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+//        itemMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
         itemMeta.addItemFlags(ItemFlag.HIDE_DESTROYS);
         itemMeta.addItemFlags(ItemFlag.HIDE_PLACED_ON);
         itemMeta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
@@ -295,12 +295,12 @@ public class PlayerListener implements Listener {
     private void toggleButton(Inventory tempInv, ItemStack button, boolean buttonStatus, String buttonText, int slot) {
         ItemMeta itemMeta = button.getItemMeta();
         if (buttonStatus) {
-            button.addUnsafeEnchantment(Enchantment.ARROW_DAMAGE, 1);
+            button.addUnsafeEnchantment(Enchantment.POWER, 1);
             String suffix = langString("lang_button_true");
             suffix = suffix.substring(0, 1).toUpperCase() + suffix.substring(1);
             Objects.requireNonNull(itemMeta, "ItemMeta doesn't exist for button.").setDisplayName(ChatColor.BLUE + buttonText + ChatColor.GREEN + suffix);
         } else {
-            button.removeEnchantment(Enchantment.ARROW_DAMAGE);
+            button.removeEnchantment(Enchantment.POWER);
             String suffix = langString("lang_button_false");
             suffix = suffix.substring(0, 1).toUpperCase() + suffix.substring(1);
             Objects.requireNonNull(itemMeta, "ItemMeta doesn't exist for button.").setDisplayName(ChatColor.BLUE + buttonText + ChatColor.RED + suffix);

--- a/src/main/java/com/ugleh/redstoneproximitysensor/trigger/IndividualMob.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/trigger/IndividualMob.java
@@ -211,7 +211,7 @@ public class IndividualMob extends TriggerTemplate implements Listener{
         itemMeta.setLore(newLore);
 
         if(!selectedRPS.getIndividualMobs().isEmpty()) {
-            itemMeta.addEnchant(Enchantment.ARROW_DAMAGE, 1, true);
+            itemMeta.addEnchant(Enchantment.POWER, 1, true);
 
         }
             return itemMeta;

--- a/src/main/java/com/ugleh/redstoneproximitysensor/util/RPS.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/util/RPS.java
@@ -155,7 +155,7 @@ public class RPS {
         int green = 21;
         int blue = 133;
         Location loc2 = new Location(loc.getWorld(), d0, d1, d2);
-        Objects.requireNonNull(loc.getWorld(), "World could not be found in Sensor: " + this.getUniqueID()).spawnParticle(Particle.REDSTONE, loc2, 1, new Particle.DustOptions(Color.fromRGB(red, green, blue), 1));
+        Objects.requireNonNull(loc.getWorld(), "World could not be found in Sensor: " + this.getUniqueID()).spawnParticle(Particle.DUST, loc2, 1, new Particle.DustOptions(Color.fromRGB(red, green, blue), 1));
 
     }
 

--- a/src/main/java/com/ugleh/redstoneproximitysensor/util/SkullCreator.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/util/SkullCreator.java
@@ -2,6 +2,7 @@ package com.ugleh.redstoneproximitysensor.util;
 
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+import net.minecraft.world.item.component.ResolvableProfile;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.SkullType;
@@ -295,7 +296,9 @@ public class SkullCreator {
                     metaProfileField = meta.getClass().getDeclaredField("profile");
                     metaProfileField.setAccessible(true);
                 }
-                metaProfileField.set(meta, makeProfile(b64));
+                GameProfile gameProfile = makeProfile(b64);
+                ResolvableProfile resolveableProfile = new ResolvableProfile(gameProfile);
+                metaProfileField.set(meta, resolveableProfile);
 
             } catch (NoSuchFieldException | IllegalAccessException ex2) {
                 ex2.printStackTrace();

--- a/src/main/java/com/ugleh/redstoneproximitysensor/util/Trigger.java
+++ b/src/main/java/com/ugleh/redstoneproximitysensor/util/Trigger.java
@@ -72,7 +72,7 @@ public class Trigger{
             itemMeta.setLore(this.lore);
             itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-            itemMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+//            itemMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
             itemMeta.addItemFlags(ItemFlag.HIDE_DESTROYS);
             itemMeta.addItemFlags(ItemFlag.HIDE_PLACED_ON);
             itemMeta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
@@ -102,11 +102,11 @@ public class Trigger{
         ItemMeta itemMeta = item.getItemMeta();
         if (itemMeta != null) {
             if (selectedRPS.getAcceptedTriggerFlags().contains(flagName)) {
-                itemMeta.addEnchant(Enchantment.ARROW_DAMAGE, 1, true);
+                itemMeta.addEnchant(Enchantment.POWER, 1, true);
                 String suffix = (suffixOne == null) ? ("") : (": " + ChatColor.GREEN + suffixOne);
                 itemMeta.setDisplayName(ChatColor.BLUE + displayNamePrefix + suffix);
             } else {
-                itemMeta.removeEnchant(Enchantment.ARROW_DAMAGE);
+                itemMeta.removeEnchant(Enchantment.POWER);
                 String suffix = (suffixTwo == null) ? ("") : (": " + ChatColor.RED + suffixTwo);
                 itemMeta.setDisplayName(ChatColor.BLUE + displayNamePrefix + suffix);
             }


### PR DESCRIPTION
Basically fixes #16. I updated the dependencies and repos to make it compile again, fixed a few enum values to fit to the newer MC versions and fixed the SkullCreator. 

I think it will not run on previous MC versions anymore tho. If thats desired, we need to compile it again against older mc versions and make the skull-thingy more flexible to only use the `ResolvableProfile` when its required as a parameter for setting the profile.

Tested on  `paper-1.21.1-98`.